### PR TITLE
Remove fontify-regexp-at-point from the readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,7 +53,6 @@
      - =C-c / e ′= :: =rxt-elisp-to-strings=
      - =C-c / e t= :: =rxt-toggle-elisp-rx=
      - =C-c / t= :: =rxt-toggle-elisp-rx=
-     - =C-c / h= :: =rxt-fontify-regexp-at-point=
 
 *** Interactive input and output
     When used interactively, the conversion commands can read a regexp


### PR DESCRIPTION
It has already been removed in dbb1a41.