### PR TITLE
Correct use of eval-after-load

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -881,7 +881,7 @@ emulated PCRE regexps when `isearch-regexp' is true."
               (pcre-decorate-search-function real-search-function)))
     ad-do-it))
 
-(eval-after-load "evil"
+(eval-after-load 'evil
   '(when pcre-mode
     (ad-enable-advice 'evil-search-function 'around 'pcre-mode)
     (ad-activate 'evil-search-function)))


### PR DESCRIPTION
With a symbol, only the file providing the feature triggers the
eval-after-load. With a string, any file named the same way triggers
it. This is problematic for custom configurations named after
packages.