### PR TITLE
update function preceding-sexp

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -555,7 +555,7 @@ these commands only."
           (condition-case nil
               (save-excursion
                 (while (nth 3 (syntax-ppss)) (forward-char))
-                (let ((re (eval (preceding-sexp))))
+                (let ((re (eval (elisp--  preceding-sexp))))
                   (if (stringp re) re
                     (read-string prompt))))
             (error


### PR DESCRIPTION
Function `preceding-sexp` is obsolete from Emacs 25.1