### PR TITLE
Use built-in `cl-lib` instead of `a`

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -8,7 +8,7 @@
 ;; Updated:			13 December 2015
 ;; Version:                     1.9
 ;; Url:                         https://github.com/joddie/pcre2el
-;; Package-Requires:            ((emacs "25.1") (cl-lib "0.3") (a "1.0.0"))
+;; Package-Requires:            ((emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -1922,8 +1922,8 @@ Example:
                  (let* ((split-point (/ (+ start end) 2))
                         (left (recur start split-point))
                         (right (recur (1+ split-point) end)))
-                   (a-merge left right))))))
-         (a-merge (left right)
+                   (cl-merge left right))))))
+         (cl-merge (left right)
            (cond ((null left) right)
                  ((null right) left)
                  (t

--- a/pcre2el.el
+++ b/pcre2el.el
@@ -6,7 +6,7 @@
 ;; Hacked additionally by:	opensource at hardakers dot net
 ;; Created:			14 Feb 2012
 ;; Updated:			13 December 2015
-;; Version:                     1.9
+;; Version:                     1.10
 ;; Url:                         https://github.com/joddie/pcre2el
 ;; Package-Requires:            ((emacs "25.1"))
 


### PR DESCRIPTION
In 3e235acf95a13124e7c1529e65b520120f13ad9f and 04175c0f85146340b4c56d60b771968c8edabf10, the call to the `merge` function (from the old built-in package `cl`) was replaced with a call to `a-merge` from `a`. This introduces a dependency on a package that is not on GNU ELPA or NonGNU ELPA, meaning that users can't install `pcre2el` from there without adding another package archive (usually MELPA).

Luckily, we can just use the built-in `cl-merge` instead, which is a drop-in replacement for the old `merge` function. That function is in the built-in package `cl-lib`, which is the replacement for the old `cl` package. Note that the move from `cl` to `cl-lib` is basically just a rename - the behaviour should be exactly the same as before. (If it's not, that's likely to be a bug.)

So I make that change here. Note that since we depend on Emacs 25.1, there is no need to depend explicitly on `cl-lib` (as it comes built-in with that version), so I remove that redundant dependency also. I also bump the `pcre2el` version so that a new release is made on NonGNU ELPA, with the fixed dependency. 

Please consider merging this. Thanks in advance.

See also:
    https://github.com/plexus/a.el#should-you-use-it-for-new-code