### PR TITLE
Don't require package "a"

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -449,7 +449,6 @@
 (require 'advice)
 (require 'ring)
 (require 'pcase)
-(require 'a)
 
 ;;; Customization group
 (defgroup rxt nil
@@ -1922,8 +1921,8 @@ Example:
                  (let* ((split-point (/ (+ start end) 2))
                         (left (recur start split-point))
                         (right (recur (1+ split-point) end)))
-                   (cl-merge left right))))))
-         (cl-merge (left right)
+                   (pcre2el-merge left right))))))
+         (pcre2el-merge (left right)
            (cond ((null left) right)
                  ((null right) left)
                  (t

--- a/pcre2el.el
+++ b/pcre2el.el
@@ -6,7 +6,7 @@
 ;; Hacked additionally by:	opensource at hardakers dot net
 ;; Created:			14 Feb 2012
 ;; Updated:			13 December 2015
-;; Version:                     1.10
+;; Version:                     1.11
 ;; Url:                         https://github.com/joddie/pcre2el
 ;; Package-Requires:            ((emacs "25.1"))
 


### PR DESCRIPTION
This removes an unnecessary require of `a`, and renames an internal function to be less confusing. See #47.

It also bumps the version yet again for NonGNU ELPA, so that we have a working version there.

Thanks.