### PR TITLE
Use ‘reb-target-value’ instead of ‘reb-target-binding’ if available

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -3124,7 +3124,9 @@ in character classes as outside them."
   (around rxt () activate compile)
   "This function is hacked for emulated PCRE syntax and regexp conversion."
   (if (eq reb-re-syntax 'pcre)
-      (let ((src (reb-target-binding reb-regexp-src)))
+      (let ((src (if (fboundp #'reb-target-value)
+                     (reb-target-value 'reb-regexp-src)
+                   (reb-target-binding reb-regexp-src))))
         (if src
             (insert "\n/" (replace-regexp-in-string "/" "\\/" src t t) "/")
           (insert "\n//")))


### PR DESCRIPTION
This seems to work just fine using a copy of Emacs built from `master` this morning.

Closes #51