### PR TITLE
Silence byte-compiler dealing with replaced function

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -3124,9 +3124,11 @@ in character classes as outside them."
   (around rxt () activate compile)
   "This function is hacked for emulated PCRE syntax and regexp conversion."
   (if (eq reb-re-syntax 'pcre)
-      (let ((src (if (fboundp #'reb-target-value)
-                     (reb-target-value 'reb-regexp-src)
-                   (reb-target-binding reb-regexp-src))))
+      (let ((src (cond ((fboundp 'reb-target-value)
+                        (reb-target-value 'reb-regexp-src))
+                       ((fboundp 'reb-target-binding)
+                        (reb-target-binding reb-regexp-src))
+                       ((error "BUG")))))
         (if src
             (insert "\n/" (replace-regexp-in-string "/" "\\/" src t t) "/")
           (insert "\n//")))


### PR DESCRIPTION
In [1: 34b35c0] we started to use the function/macro available
in the current Emacs version.  This commit additionally keeps
the byte-compiler from reporting that the other is undefined.

1: 2023-01-03 34b35c0ba0f4d0658705591467617e9d7b3c516c
   Use ‘reb-target-value’ instead of ‘reb-target-binding’ if available