### PR TITLE
Fix: Obsolete `buffer-substring` function replaced with `buffer-subst…

### DIFF
--- a/pcre2el.el
+++ b/pcre2el.el
@@ -660,7 +660,7 @@ Note that this does not apply to backreferences."
   (reb-do-update))
 
 (defun rxt--toggle-flag-minibuffer (char)
-  (setf (buffer-substring (minibuffer-prompt-end) (point-max))
+  (setf (buffer-substring-no-properties (minibuffer-prompt-end) (point-max))
         (rxt--toggle-flag-string (minibuffer-contents) char))
   (when
       (and (= (point) (minibuffer-prompt-end))
@@ -2493,7 +2493,7 @@ in character classes as outside them."
         (let ((begin (point)))
           (search-forward ")" nil 'go-to-end)
           (rxt-error "Unrecognized PCRE extended construction `(*%s'"
-                     (buffer-substring begin (point))))))
+                     (buffer-substring-no-properties begin (point))))))
 
       ;; Parse the remainder of the subgroup
       (unless shy (cl-incf rxt-subgroup-count))


### PR DESCRIPTION
…ring-no-properties`

* Replaced `buffer-substring` with `buffer-substring-no-properties` to avoid using an obsolete function.
* Updated code to use the recommended function for extracting substrings from the current buffer.